### PR TITLE
rake is required for development

### DIFF
--- a/jenkins-remote-api.gemspec
+++ b/jenkins-remote-api.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 2.6'
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'aruba'
+  s.add_development_dependency 'rake'
   s.add_dependency 'terminal-table'
   s.add_dependency 'thor'    
   s.add_dependency 'mechanize', '~>2.0.1'


### PR DESCRIPTION
I added Rake as a development requirement because if you don't have it installed already, then you can't use rake...especially with Bundler enabled.
