### PR TITLE
cucumber: fixed the expended external data

### DIFF
--- a/features/jenkins.feature
+++ b/features/jenkins.feature
@@ -2,38 +2,44 @@ Feature: Jenkins
   In order to consume jenkins api
   As a CLI
   I want to be as objective as possible
-	
+
 	Scenario: Get ci address when you set it
 		When I run `jenkins ci_address_to http://deadlock.netbeans.org/hudson`
 		Then the output should contain "http://deadlock.netbeans.org/hudson/"
-	
+
 	Scenario: Get list all job names for specific jenkins ci
-		When I run `jenkins list_all_job_names --ci_address http://ci.jruby.org/view/Ruboto/`
+		When I run `jenkins list_all_job_names --ci_address http://ci.jruby.org/view/JRuby%20Core/`
 	    Then the output should exactly equal to following without caring about space:
-	         """		
-			+-------------------------------+
-			| Job Name                      |
-			+-------------------------------+
-			| ruboto-core                   |
-			| ruboto-core_jruby_master      |
-			| ruboto-core_pads              |
-			| ruboto-core_pads_jruby_master |
-			+-------------------------------+
-	         """    	    
+	         """
+			+-------------------------+
+			| Job Name                |
+			+-------------------------+
+			| jruby-base              |
+			| jruby-dist              |
+			| jruby-git               |
+			| jruby-test-all          |
+			| jruby-test-jar-complete |
+			| jruby-windows           |
+			| spec-ci                 |
+			+-------------------------+
+	         """
 
 	Scenario: Get all jobs descriptions for specific ci
-	  When I run `jenkins jobs_description --ci_address http://ci.jruby.org/view/Ruboto/`
+	  When I run `jenkins jobs_description --ci_address http://ci.jruby.org/view/JRuby%20Core/`
 	  Then the output should exactly equal to following without caring about space:
 	         """
-			+-------------------------------+------------+--------------------------------------------------------+
-			| Job Name                      | Job Status | Job URL                                                |
-			+-------------------------------+------------+--------------------------------------------------------+
-			| ruboto-core                   | building   | http://ci.jruby.org/job/ruboto-core/                   |
-			| ruboto-core_jruby_master      | failure    | http://ci.jruby.org/job/ruboto-core_jruby_master/      |
-			| ruboto-core_pads              | building   | http://ci.jruby.org/job/ruboto-core_pads/              |
-			| ruboto-core_pads_jruby_master | failure    | http://ci.jruby.org/job/ruboto-core_pads_jruby_master/ |
-			+-------------------------------+------------+--------------------------------------------------------+
-	         """    	    
+			+-------------------------+------------+--------------------------------------------------+
+			| Job Name                | Job Status | Job URL                                          |
+			+-------------------------+------------+--------------------------------------------------+
+			| jruby-base              | failure    | http://ci.jruby.org/job/jruby-base/              |
+			| jruby-dist              | failure    | http://ci.jruby.org/job/jruby-dist/              |
+			| jruby-git               | success    | http://ci.jruby.org/job/jruby-git/               |
+			| jruby-test-all          | failure    | http://ci.jruby.org/job/jruby-test-all/          |
+			| jruby-test-jar-complete | success    | http://ci.jruby.org/job/jruby-test-jar-complete/ |
+			| jruby-windows           | failure    | http://ci.jruby.org/job/jruby-windows/           |
+			| spec-ci                 | failure    | http://ci.jruby.org/job/spec-ci/                 |
+			+-------------------------+------------+--------------------------------------------------+
+	         """
 
 	Scenario: Prompt error info when ci address for list all job names has no job infos
 		When I run `jenkins list_all_job_names --ci_address http://www.google.com/`
@@ -41,17 +47,17 @@ Feature: Jenkins
 
 	Scenario: Prompt error info when ci address for list all job names return xml that is illegal
 		When I run `jenkins list_all_job_names --ci_address http://www.baidu.com/`
-		Then the output should contain "Error parsing xml from http://www.baidu.com/api/xml due to format."		
-   
+		Then the output should contain "Error parsing xml from http://www.baidu.com/api/xml due to format."
+
 	Scenario: Get current build status for job for specific ci
-	  When I run `jenkins current_status --job_name ruboto-core --ci_address http://ci.jruby.org/view/Ruboto/`
+	  When I run `jenkins current_status --job_name ruboto-core --ci_address http://ci.jruby.org/`
 	  Then the output should exactly equal to following without caring about space:
          """
-				+-------------+----------+
-				| Job Name    | Status   |
-				+-------------+----------+
-				| ruboto-core | building |
-				+-------------+----------+
-         """    	    
-	
+				+-------------+---------+
+				| Job Name    | Status  |
+				+-------------+---------+
+				| ruboto-core | failure |
+				+-------------+---------+
+         """
+
 

--- a/features/step_definitions/aruba_steps.rb
+++ b/features/step_definitions/aruba_steps.rb
@@ -15,4 +15,3 @@ Then /^the output should exactly equal to following without caring about space:$
   all_output.to_s.split.join('').should == partial_output.split.join('')
 end
 
-


### PR DESCRIPTION
Apparently the views for the ci-jruby.org Jenkin's instance has
changed.

This is just temporary, since it uses live data, and it'll change
constantly.  A better solution needs to be figured out.  Either just
checking for the header (and possibly one or more results) or by stubbing
the data returned to the gem.
