### PR TITLE
Add travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+rvm:
+  - 1.9.2
+script: "bundle exec rake travis"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Jenkins Remote API
 =============
 
+[![Build Status](https://secure.travis-ci.org/tuo/jenkins-remote-api.png)](http://travis-ci.org/tuo/jenkins-remote-api)
+
 A gem aims at help you consume [remote-access-api](https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API) offered by [Jenkins](http://jenkins-ci.org/). 
 
 Why

--- a/Rakefile
+++ b/Rakefile
@@ -17,5 +17,11 @@ Cucumber::Rake::Task.new(:features) do |task|
   task.cucumber_opts = ["features"]
 end
 
+desc "Travis CI task"
+task :travis do |task|
+  Rake::Task["spec"].invoke
+  Rake::Task["features"].invoke
+end
+
 desc "Run all tests"
 task :test => [:spec, :features]

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,21 @@
 require 'bundler'
+require 'rspec/core/rake_task'
+require "cucumber/rake/task"
+
+task :default => :test
+
+# Gem Tasks
 Bundler::GemHelper.install_tasks
+
+desc "Run specs"
+RSpec::Core::RakeTask.new do |task|
+  task.pattern = "./spec/**/*_spec.rb" # don't need this, it's default.
+end
+
+desc "Run features"
+Cucumber::Rake::Task.new(:features) do |task|
+  task.cucumber_opts = ["features"]
+end
+
+desc "Run all tests"
+task :test => [:spec, :features]

--- a/jenkins-remote-api.gemspec
+++ b/jenkins-remote-api.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 2.6'
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'aruba'
+  s.add_development_dependency 'rake'
   s.add_dependency 'terminal-table'
   s.add_dependency 'thor'    
   s.add_dependency 'mechanize', '~>2.0.1'


### PR DESCRIPTION
This add support for Travis (not Jenkins, but it works really well with github ruby projects and is available for everyone).

It'll put the travis-ci icon showing the current status in the readme.  All you have to do is login to travis-ci (using your github account) and then turn on this project.  That's it.

This rolls in some of my other pull requests (specifically, the two rake ones) since they have to be in place for this to work.  The features tests will fail, but I have a separate pull request for that.
