### PR TITLE
Add support for password protected Jenkins installations

### DIFF
--- a/features/jenkins.feature
+++ b/features/jenkins.feature
@@ -11,28 +11,28 @@ Feature: Jenkins
 		When I run `jenkins list_all_job_names --ci_address http://ci.jruby.org/view/Ruboto/`
 	    Then the output should exactly equal to following without caring about space:
 	         """		
-			+-------------------------------+
-			| Job Name                      |
-			+-------------------------------+
-			| ruboto-core                   |
-			| ruboto-core_jruby_master      |
-			| ruboto-core_pads              |
-			| ruboto-core_pads_jruby_master |
-			+-------------------------------+
+			+--------------------------+
+			| Job Name                 |
+			+--------------------------+
+			| ruboto                   |
+			| ruboto_jruby_master      |
+			| ruboto_pads              |
+			| ruboto_pads_jruby_master |
+			+--------------------------+
 	         """    	    
 
 	Scenario: Get all jobs descriptions for specific ci
 	  When I run `jenkins jobs_description --ci_address http://ci.jruby.org/view/Ruboto/`
 	  Then the output should exactly equal to following without caring about space:
 	         """
-			+-------------------------------+------------+--------------------------------------------------------+
-			| Job Name                      | Job Status | Job URL                                                |
-			+-------------------------------+------------+--------------------------------------------------------+
-			| ruboto-core                   | building   | http://ci.jruby.org/job/ruboto-core/                   |
-			| ruboto-core_jruby_master      | failure    | http://ci.jruby.org/job/ruboto-core_jruby_master/      |
-			| ruboto-core_pads              | building   | http://ci.jruby.org/job/ruboto-core_pads/              |
-			| ruboto-core_pads_jruby_master | failure    | http://ci.jruby.org/job/ruboto-core_pads_jruby_master/ |
-			+-------------------------------+------------+--------------------------------------------------------+
+			+--------------------------+------------+---------------------------------------------------+
+			| Job Name                 | Job Status | Job URL                                           |
+			+--------------------------+------------+---------------------------------------------------+
+			| ruboto                   | success    | http://ci.jruby.org/job/ruboto/                   |
+			| ruboto_jruby_master      | building   | http://ci.jruby.org/job/ruboto_jruby_master/      |
+			| ruboto_pads              | failure    | http://ci.jruby.org/job/ruboto_pads/              |
+			| ruboto_pads_jruby_master | failure    | http://ci.jruby.org/job/ruboto_pads_jruby_master/ |
+			+--------------------------+------------+---------------------------------------------------+
 	         """    	    
 
 	Scenario: Prompt error info when ci address for list all job names has no job infos
@@ -44,14 +44,14 @@ Feature: Jenkins
 		Then the output should contain "Error parsing xml from http://www.baidu.com/api/xml due to format."		
    
 	Scenario: Get current build status for job for specific ci
-	  When I run `jenkins current_status --job_name ruboto-core --ci_address http://ci.jruby.org/view/Ruboto/`
+	  When I run `jenkins current_status --job_name ruboto --ci_address http://ci.jruby.org/view/Ruboto/`
 	  Then the output should exactly equal to following without caring about space:
          """
-				+-------------+----------+
-				| Job Name    | Status   |
-				+-------------+----------+
-				| ruboto-core | building |
-				+-------------+----------+
+				+----------+---------+
+				| Job Name | Status  |
+				+----------+---------+
+				| ruboto   | success |
+				+----------+---------+
          """    	    
 	
 

--- a/lib/jenkins-remote-api/ci/helper/xml_helper.rb
+++ b/lib/jenkins-remote-api/ci/helper/xml_helper.rb
@@ -1,22 +1,64 @@
 require 'rubygems'
 require 'mechanize'
+require 'base64'
 module Ci
-    module XmlHelper
-     private
-      def retrieve_xml_from(url)
-        xml = nil
-        begin  
-          Mechanize.new.get(url) do |page|
-            xml = page.body
-          end
-        rescue Mechanize::ResponseCodeError => e
-          raise "Error in grabbing xml of #{url}.Pls refer to response code:#{e.response_code}."
-        end     
-        xml 
-      end
-      
-      def url_with_appended_xml url
-         url + "api/xml"
-      end
+  module XmlHelper
+
+    def initialize
+      @options = {}
     end
+
+    private
+
+    # Get XML from url
+    #
+    # Returns HTTP content from url
+    def retrieve_xml_from(url, options = {})
+      @options = options
+      agent = Mechanize.new
+      begin
+        xml = retrieve_get(agent, url)
+      rescue Mechanize::ResponseCodeError => e
+        raise "Error in grabbing xml of #{url}.Pls refer to response code:#{e.response_code}."
+      end
+      xml
+    end
+
+    # Get call to mechanize
+    #
+    # Returns content from url
+    def retrieve_get(agent_obj, url)
+      xml = nil
+      if @options.empty?
+        agent_obj.get(url) { |page| xml = page.body }
+      else
+        agent_obj.get(url, [], nil, headers) { |page| xml = page.body }
+      end
+      xml
+    end
+
+    # Creating an Authorization header for password protected
+    # Jenkins servers
+    #
+    # Returns hash of Auth Basic or empty hash if no credentials exists
+    def headers
+      return {} if @options.nil? || @options.empty?
+      { 'Authorization' => "Basic #{token}" }
+    end
+
+    # Building the token
+    #
+    # Returns base64 encoded string of username and password
+    def token
+      t = [@options[:username], @options[:password]].join(':')
+      Base64.encode64(t).delete("\r\n")
+    end
+
+    # Appending api/xml to url
+    #
+    # Returns string url with api/xml appended
+    def url_with_appended_xml(url)
+        url + "api/xml"
+    end
+  end
 end

--- a/lib/jenkins-remote-api/ci/jenkins.rb
+++ b/lib/jenkins-remote-api/ci/jenkins.rb
@@ -9,8 +9,18 @@ module Ci
     
     attr_accessor :ci_address
     
-    def initialize url
+    def initialize url, auth = {}
       @ci_address = url
+      unless auth.empty?
+        @options = {
+          :username => auth[:username],
+          :password => auth[:password]
+        }
+      end
+    end
+
+    def options
+      @options ||= {}
     end
 
     def ci_address
@@ -56,7 +66,7 @@ module Ci
     
       def cached_xml_doc_of_jobs
         return @jobs_highlevel_xml unless @jobs_highlevel_xml.nil?
-        xml = retrieve_xml_from(xml_url_on_ci)
+        xml = retrieve_xml_from(xml_url_on_ci, options)
         parser = LibXML::XML::Parser.string(xml)        
         begin 
           @jobs_highlevel_xml = parser.parse

--- a/spec/jenkins_spec.rb
+++ b/spec/jenkins_spec.rb
@@ -9,6 +9,15 @@ describe Ci::Jenkins do
     jenkins.ci_address.should == ci_url
   end
 
+  it "should be able to login to password protected server" do
+    username = 'test'
+    password = 'test2'
+    job_included = 'test_job'
+    protected_ci_url = 'http://example.com'
+    password_protected = Ci::Jenkins.new(ci_url, :username => username, :password => password)
+    #password_protected.list_all_job_names.include?(job_included).should == true
+  end
+
   it "should set initialize jenkins instance with ci address" do
     jenkins_without_end_slash = Ci::Jenkins.new("helloworld.com")
     jenkins_without_end_slash.ci_address.should == "helloworld.com/"


### PR DESCRIPTION
I have been playing some with the jenkins-remote-api and thought it would be nice to have support for password protected installations. I have tested the implementation on a local VM and it works really well. Had to disable the test due to not having any public Jenkins installations that has got password protection. Would be great if there were any around to test against.

I also updated some Cucumber tests that were failing and added some documentation in the xml_helper file.

Would be great to see it merged,
Cheers!
